### PR TITLE
FB-367 Update node and npm versions

### DIFF
--- a/docs/integration.mdx
+++ b/docs/integration.mdx
@@ -12,12 +12,12 @@ In this example, we will use Node and NPM with specific versions as below.
 
 ```shell
 $ node --version
-20.11.0
+20.19.5
 ```
 
 ```shell
 $ npm --version
-10.4.0
+10.8.2
 ```
 
 ## Create a new project


### PR DESCRIPTION
The newest version of vite requires Node.js version 20.19+ or 22.12+